### PR TITLE
cluster type added

### DIFF
--- a/packages/gill/src/core/create-solana-client.ts
+++ b/packages/gill/src/core/create-solana-client.ts
@@ -1,7 +1,7 @@
 import type { DevnetUrl, MainnetUrl, TestnetUrl } from "@solana/kit";
 import { createSolanaRpc, createSolanaRpcSubscriptions } from "@solana/kit";
 
-import type { Cluster, CreateSolanaClientArgs, LocalnetUrl, ModifiedClusterUrl, SolanaClient } from "../types/rpc";
+import type { CreateSolanaClientArgs, LocalnetUrl, ModifiedClusterUrl, SolanaClient } from "../types/rpc";
 import { getPublicSolanaRpcUrl } from "./rpc";
 import { sendAndConfirmTransactionWithSignersFactory } from "./send-and-confirm-transaction-with-signers";
 import { simulateTransactionFactory } from "./simulate-transaction";
@@ -11,25 +11,25 @@ import { simulateTransactionFactory } from "./simulate-transaction";
  */
 export function createSolanaClient(
   props: Omit<CreateSolanaClientArgs<MainnetUrl | "mainnet">, "urlOrMoniker"> & {
-    cluster: Cluster.Mainnet;
+    cluster: "mainnet",
     urlOrMoniker: "mainnet";
   },
 ): SolanaClient<MainnetUrl>;
 export function createSolanaClient(
   props: Omit<CreateSolanaClientArgs<DevnetUrl | "devnet">, "urlOrMoniker"> & {
-    cluster: Cluster.Devnet;
+    cluster: "devnet",
     urlOrMoniker: "devnet";
   },
 ): SolanaClient<DevnetUrl>;
 export function createSolanaClient(
   props: Omit<CreateSolanaClientArgs<TestnetUrl | "testnet">, "urlOrMoniker"> & {
-    cluster: Cluster.Testnet;
+    cluster: "testnet";
     urlOrMoniker: "testnet";
   },
 ): SolanaClient<TestnetUrl>;
 export function createSolanaClient(
   props: Omit<CreateSolanaClientArgs<LocalnetUrl | "localnet">, "urlOrMoniker"> & {
-    cluster: Cluster.Localnet;
+    cluster: "localnet";
     urlOrMoniker: "localnet";
   },
 ): SolanaClient<LocalnetUrl>;
@@ -41,7 +41,7 @@ export function createSolanaClient<TCluster extends ModifiedClusterUrl>({
   urlOrMoniker,
   rpcConfig,
   rpcSubscriptionsConfig,
-}: CreateSolanaClientArgs<TCluster> & { cluster: Cluster}) {
+}: CreateSolanaClientArgs<TCluster>) {
   if (!urlOrMoniker) throw new Error("Cluster url or moniker is required");
   if (urlOrMoniker instanceof URL == false) {
     try {

--- a/packages/gill/src/core/create-solana-client.ts
+++ b/packages/gill/src/core/create-solana-client.ts
@@ -1,7 +1,7 @@
 import type { DevnetUrl, MainnetUrl, TestnetUrl } from "@solana/kit";
 import { createSolanaRpc, createSolanaRpcSubscriptions } from "@solana/kit";
 
-import type { CreateSolanaClientArgs, LocalnetUrl, ModifiedClusterUrl, SolanaClient } from "../types/rpc";
+import type { Cluster, CreateSolanaClientArgs, LocalnetUrl, ModifiedClusterUrl, SolanaClient } from "../types/rpc";
 import { getPublicSolanaRpcUrl } from "./rpc";
 import { sendAndConfirmTransactionWithSignersFactory } from "./send-and-confirm-transaction-with-signers";
 import { simulateTransactionFactory } from "./simulate-transaction";
@@ -11,21 +11,25 @@ import { simulateTransactionFactory } from "./simulate-transaction";
  */
 export function createSolanaClient(
   props: Omit<CreateSolanaClientArgs<MainnetUrl | "mainnet">, "urlOrMoniker"> & {
+    cluster: Cluster.Mainnet;
     urlOrMoniker: "mainnet";
   },
 ): SolanaClient<MainnetUrl>;
 export function createSolanaClient(
   props: Omit<CreateSolanaClientArgs<DevnetUrl | "devnet">, "urlOrMoniker"> & {
+    cluster: Cluster.Devnet;
     urlOrMoniker: "devnet";
   },
 ): SolanaClient<DevnetUrl>;
 export function createSolanaClient(
   props: Omit<CreateSolanaClientArgs<TestnetUrl | "testnet">, "urlOrMoniker"> & {
+    cluster: Cluster.Testnet;
     urlOrMoniker: "testnet";
   },
 ): SolanaClient<TestnetUrl>;
 export function createSolanaClient(
   props: Omit<CreateSolanaClientArgs<LocalnetUrl | "localnet">, "urlOrMoniker"> & {
+    cluster: Cluster.Localnet;
     urlOrMoniker: "localnet";
   },
 ): SolanaClient<LocalnetUrl>;
@@ -33,10 +37,11 @@ export function createSolanaClient<TClusterUrl extends ModifiedClusterUrl>(
   props: CreateSolanaClientArgs<TClusterUrl>,
 ): SolanaClient<TClusterUrl>;
 export function createSolanaClient<TCluster extends ModifiedClusterUrl>({
+  cluster,
   urlOrMoniker,
   rpcConfig,
   rpcSubscriptionsConfig,
-}: CreateSolanaClientArgs<TCluster>) {
+}: CreateSolanaClientArgs<TCluster> & { cluster: Cluster}) {
   if (!urlOrMoniker) throw new Error("Cluster url or moniker is required");
   if (urlOrMoniker instanceof URL == false) {
     try {
@@ -74,6 +79,7 @@ export function createSolanaClient<TCluster extends ModifiedClusterUrl>({
   );
 
   return {
+    cluster,
     rpc,
     rpcSubscriptions,
     sendAndConfirmTransaction: sendAndConfirmTransactionWithSignersFactory({

--- a/packages/gill/src/types/rpc.ts
+++ b/packages/gill/src/types/rpc.ts
@@ -24,15 +24,10 @@ export type ModifiedClusterUrl = MainnetUrl | DevnetUrl | TestnetUrl | LocalnetU
 
 export type SolanaClientUrlOrMoniker = SolanaClusterMoniker | URL | ModifiedClusterUrl;
 
-export enum Cluster {
-  Mainnet = "mainnet",
-  Devnet = "devnet",
-  Localnet = "localnet",
-  Testnet = "testnet",
-}
+export type Cluster = "devnet" | "localnet" | "mainnet" | "testnet";
 
 export type CreateSolanaClientArgs<TClusterUrl extends SolanaClientUrlOrMoniker = GenericUrl> = {
-    cluster: Cluster,
+    cluster: Cluster;
   /** Full RPC URL (for a private RPC endpoint) or the Solana moniker (for a public RPC endpoint) */
   urlOrMoniker: SolanaClientUrlOrMoniker | TClusterUrl;
   /** Configuration used to create the `rpc` client */

--- a/packages/gill/src/types/rpc.ts
+++ b/packages/gill/src/types/rpc.ts
@@ -24,7 +24,15 @@ export type ModifiedClusterUrl = MainnetUrl | DevnetUrl | TestnetUrl | LocalnetU
 
 export type SolanaClientUrlOrMoniker = SolanaClusterMoniker | URL | ModifiedClusterUrl;
 
+export enum Cluster {
+  Mainnet = "mainnet",
+  Devnet = "devnet",
+  Localnet = "localnet",
+  Testnet = "testnet",
+}
+
 export type CreateSolanaClientArgs<TClusterUrl extends SolanaClientUrlOrMoniker = GenericUrl> = {
+    cluster: Cluster,
   /** Full RPC URL (for a private RPC endpoint) or the Solana moniker (for a public RPC endpoint) */
   urlOrMoniker: SolanaClientUrlOrMoniker | TClusterUrl;
   /** Configuration used to create the `rpc` client */
@@ -34,6 +42,7 @@ export type CreateSolanaClientArgs<TClusterUrl extends SolanaClientUrlOrMoniker 
 };
 
 export type SolanaClient<TClusterUrl extends ModifiedClusterUrl | string = string> = {
+    cluster: Cluster,
   /** Used to make RPC calls to your RPC provider */
   rpc: RpcFromTransport<
     SolanaRpcApiFromTransport<RpcTransportFromClusterUrl<TClusterUrl>>,

--- a/packages/react/src/hooks/client.ts
+++ b/packages/react/src/hooks/client.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Cluster, createSolanaClient, type SolanaClient } from "gill";
+import { createSolanaClient, type SolanaClient } from "gill";
 import { GILL_HOOK_CLIENT_KEY } from "../const.js";
 
 /**
@@ -12,7 +12,7 @@ export function useSolanaClient(): SolanaClient {
     // fallback data should not be reached if used within `SolanaProvider`
     // since we set the initial value. but just in case => devnet
     initialData: createSolanaClient({
-      cluster: Cluster.Devnet,
+      cluster: "devnet",
       urlOrMoniker: "devnet",
     }),
   });

--- a/packages/react/src/hooks/client.ts
+++ b/packages/react/src/hooks/client.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { createSolanaClient, type SolanaClient } from "gill";
+import { Cluster, createSolanaClient, type SolanaClient } from "gill";
 import { GILL_HOOK_CLIENT_KEY } from "../const.js";
 
 /**
@@ -12,6 +12,7 @@ export function useSolanaClient(): SolanaClient {
     // fallback data should not be reached if used within `SolanaProvider`
     // since we set the initial value. but just in case => devnet
     initialData: createSolanaClient({
+      cluster: Cluster.Devnet,
       urlOrMoniker: "devnet",
     }),
   });


### PR DESCRIPTION
### Problem
We need @solana/react hooks to effectively communicate with Wallet. But most of the @solana/react hooks require account and chain. We don't have specific chain or cluster information, which cluster or chain we are currently connected with.

### Summary of Changes
1. Added Cluster enum in packages/gill/src/types/rpc.ts
2. Used that cluster enum to create solana client in packages/gill/src/core/create-solana-client.ts
3. Pass cluster type in packages/react/src/hooks/client.ts to create solana client

Fixes #
We can give cluster type while creating solana client, and We can access which cluster or chain we are currently connected with.