### PR TITLE
Sign transaction

### DIFF
--- a/packages/gill/src/core/create-solana-client.ts
+++ b/packages/gill/src/core/create-solana-client.ts
@@ -11,21 +11,25 @@ import { simulateTransactionFactory } from "./simulate-transaction";
  */
 export function createSolanaClient(
   props: Omit<CreateSolanaClientArgs<MainnetUrl | "mainnet">, "urlOrMoniker"> & {
+    cluster: "mainnet",
     urlOrMoniker: "mainnet";
   },
 ): SolanaClient<MainnetUrl>;
 export function createSolanaClient(
   props: Omit<CreateSolanaClientArgs<DevnetUrl | "devnet">, "urlOrMoniker"> & {
+    cluster: "devnet",
     urlOrMoniker: "devnet";
   },
 ): SolanaClient<DevnetUrl>;
 export function createSolanaClient(
   props: Omit<CreateSolanaClientArgs<TestnetUrl | "testnet">, "urlOrMoniker"> & {
+    cluster: "testnet";
     urlOrMoniker: "testnet";
   },
 ): SolanaClient<TestnetUrl>;
 export function createSolanaClient(
   props: Omit<CreateSolanaClientArgs<LocalnetUrl | "localnet">, "urlOrMoniker"> & {
+    cluster: "localnet";
     urlOrMoniker: "localnet";
   },
 ): SolanaClient<LocalnetUrl>;
@@ -33,6 +37,7 @@ export function createSolanaClient<TClusterUrl extends ModifiedClusterUrl>(
   props: CreateSolanaClientArgs<TClusterUrl>,
 ): SolanaClient<TClusterUrl>;
 export function createSolanaClient<TCluster extends ModifiedClusterUrl>({
+  cluster,
   urlOrMoniker,
   rpcConfig,
   rpcSubscriptionsConfig,
@@ -74,6 +79,7 @@ export function createSolanaClient<TCluster extends ModifiedClusterUrl>({
   );
 
   return {
+    cluster,
     rpc,
     rpcSubscriptions,
     sendAndConfirmTransaction: sendAndConfirmTransactionWithSignersFactory({

--- a/packages/gill/src/types/rpc.ts
+++ b/packages/gill/src/types/rpc.ts
@@ -1,39 +1,43 @@
 import type {
-  createSolanaRpc,
-  createSolanaRpcSubscriptions,
-  DevnetUrl,
-  MainnetUrl,
-  RpcFromTransport,
-  RpcSubscriptions,
-  RpcTransportFromClusterUrl,
-  SolanaRpcApiFromTransport,
-  SolanaRpcSubscriptionsApi,
-  TestnetUrl,
+    createSolanaRpc,
+    createSolanaRpcSubscriptions,
+    DevnetUrl,
+    MainnetUrl,
+    RpcFromTransport,
+    RpcSubscriptions,
+    RpcTransportFromClusterUrl,
+    SolanaRpcApiFromTransport,
+    SolanaRpcSubscriptionsApi,
+    TestnetUrl,
 } from "@solana/kit";
 import { SendAndConfirmTransactionWithSignersFunction } from "../core/send-and-confirm-transaction-with-signers";
 import type { SimulateTransactionFunction } from "../core/simulate-transaction";
 
 /** Solana cluster moniker */
-export type SolanaClusterMoniker = "mainnet" | "devnet" | "testnet" | "localnet";
+export type SolanaClusterMoniker = "devnet" | "localnet" | "mainnet" | "testnet";
 
 export type LocalnetUrl = string & { "~cluster": "localnet" };
 
 export type GenericUrl = string & {};
 
-export type ModifiedClusterUrl = MainnetUrl | DevnetUrl | TestnetUrl | LocalnetUrl | GenericUrl;
+export type ModifiedClusterUrl = DevnetUrl | GenericUrl | LocalnetUrl | MainnetUrl | TestnetUrl;
 
-export type SolanaClientUrlOrMoniker = SolanaClusterMoniker | URL | ModifiedClusterUrl;
+export type SolanaClientUrlOrMoniker = ModifiedClusterUrl | SolanaClusterMoniker | URL;
+
+export type Cluster = "devnet" | "localnet" | "mainnet" | "testnet";
 
 export type CreateSolanaClientArgs<TClusterUrl extends SolanaClientUrlOrMoniker = GenericUrl> = {
-  /** Full RPC URL (for a private RPC endpoint) or the Solana moniker (for a public RPC endpoint) */
-  urlOrMoniker: SolanaClientUrlOrMoniker | TClusterUrl;
+    cluster: Cluster;
   /** Configuration used to create the `rpc` client */
   rpcConfig?: Parameters<typeof createSolanaRpc>[1] & { port?: number };
   /** Configuration used to create the `rpcSubscriptions` client */
   rpcSubscriptionsConfig?: Parameters<typeof createSolanaRpcSubscriptions>[1] & { port?: number };
+  /** Full RPC URL (for a private RPC endpoint) or the Solana moniker (for a public RPC endpoint) */
+  urlOrMoniker: SolanaClientUrlOrMoniker | TClusterUrl;
 };
 
 export type SolanaClient<TClusterUrl extends ModifiedClusterUrl | string = string> = {
+    cluster: Cluster,
   /** Used to make RPC calls to your RPC provider */
   rpc: RpcFromTransport<
     SolanaRpcApiFromTransport<RpcTransportFromClusterUrl<TClusterUrl>>,

--- a/packages/react/src/hooks/client.ts
+++ b/packages/react/src/hooks/client.ts
@@ -12,6 +12,7 @@ export function useSolanaClient(): SolanaClient {
     // fallback data should not be reached if used within `SolanaProvider`
     // since we set the initial value. but just in case => devnet
     initialData: createSolanaClient({
+      cluster: "devnet",
       urlOrMoniker: "devnet",
     }),
   });

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -4,6 +4,7 @@ export * from "./client.js";
 export * from "./latest-blockhash.js";
 export * from "./program-accounts.js";
 export * from "./recent-prioritization-fees.js";
+export * from "./sign-transaction.js";
 export * from "./signature-statuses.js";
 export * from "./signatures-for-address.js";
 export * from "./slot.js";

--- a/packages/react/src/hooks/sign-transaction.ts
+++ b/packages/react/src/hooks/sign-transaction.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useWalletAccountTransactionSigner } from "@solana/react";
+import { getTransactionCodec, Transaction } from "gill";
+
+import { useSolanaClient } from "./client.js";
+import { useWallet } from "./wallet.js";
+
+interface UseSignTransactionReturn {
+  account: ReturnType<typeof useWallet>["account"];
+  signTransaction: (tx: Transaction) => Promise<Uint8Array>;
+  signer: ReturnType<typeof useWalletAccountTransactionSigner> | undefined;
+}
+
+export function useSignTransaction(): UseSignTransactionReturn {
+  const { account } = useWallet();
+  const {cluster} = useSolanaClient();
+
+  if(!account) throw new Error("Account is undefined")
+  const signer =  useWalletAccountTransactionSigner(account, `solana:${cluster}`);
+
+  async function signTransaction(tx: Transaction): Promise<Uint8Array> {
+    if (!account || !signer) throw new Error("Wallet not connected");
+
+    const [signedTx] = await signer.modifyAndSignTransactions([tx]);
+
+    const codec = getTransactionCodec();
+    const encodedTx = codec.encode(signedTx);
+
+    return new Uint8Array(encodedTx);
+  }
+
+  return { account, signTransaction, signer };
+}

--- a/packages/react/src/hooks/sign-transaction.ts
+++ b/packages/react/src/hooks/sign-transaction.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useWalletAccountTransactionSigner } from "@solana/react";
+import { useMutation } from "@tanstack/react-query";
 import { getTransactionCodec, Transaction } from "gill";
 
 import { useSolanaClient } from "./client.js";
@@ -8,7 +9,7 @@ import { useWallet } from "./wallet.js";
 
 interface UseSignTransactionReturn {
   account: ReturnType<typeof useWallet>["account"];
-  signTransaction: (tx: Transaction) => Promise<Uint8Array>;
+  mutation: ReturnType<typeof useMutation<Uint8Array, Error, Transaction>>;
   signer: ReturnType<typeof useWalletAccountTransactionSigner> | undefined;
 }
 
@@ -19,16 +20,18 @@ export function useSignTransaction(): UseSignTransactionReturn {
   if(!account) throw new Error("Account is undefined")
   const signer =  useWalletAccountTransactionSigner(account, `solana:${cluster}`);
 
-  async function signTransaction(tx: Transaction): Promise<Uint8Array> {
-    if (!account || !signer) throw new Error("Wallet not connected");
+  const mutation = useMutation<Uint8Array, Error, Transaction>({
+    mutationFn: async (tx: Transaction) => {
+      if (!account || !signer) throw new Error("Wallet not connected");
 
-    const [signedTx] = await signer.modifyAndSignTransactions([tx]);
+      const [signedTx] = await signer.modifyAndSignTransactions([tx]);
 
-    const codec = getTransactionCodec();
-    const encodedTx = codec.encode(signedTx);
+      const codec = getTransactionCodec();
+      const encodedTx = codec.encode(signedTx);
 
-    return new Uint8Array(encodedTx);
-  }
+      return new Uint8Array(encodedTx);
+    },
+  });
 
-  return { account, signTransaction, signer };
+  return { account, mutation, signer };
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -20,7 +20,8 @@ export * from "./providers.js";
  * Reexporting the Solana Wallet Standard functionality allows gill to
  * provide a cohesive developer experience
  */
-export * from "@solana/react";
+export { useSignAndSendTransaction, useSignIn, useSignMessage, useWalletAccountMessageSigner, useWalletAccountTransactionSendingSigner, useWalletAccountTransactionSigner } from "@solana/react";
 export * from "@solana/wallet-standard-features";
 export * from "@wallet-standard/core";
 export * from "@wallet-standard/react";
+


### PR DESCRIPTION
### Problem
Sign Transaction support via useSignTransactionHook


### Summary of Changes
Added useSignTransaction which takes transaction as input, uses useWalletAccountTransactionSigner from @solana/react to sign transaction


Fixes #